### PR TITLE
Fix missing repec command by declaring scripts as dynamic in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "nameparser",
   "titlecase",
 ]
+dynamic = ["scripts"]
 
 
 [project.urls]


### PR DESCRIPTION
The repec command was not installed due to the scripts entry not being dynamically recognized in pyproject.toml. This PR adds dynamic = ["scripts"] to the [project] table, ensuring the repec entry point is correctly created during installation.

Steps to Reproduce:

Run pip install -e . -v in the virtual environment.
Notice the warning about scripts being ignored.
repec command is not found after installation.